### PR TITLE
Fix typo in the Guardrails Quickstart Demo readme

### DIFF
--- a/guardrails-quickstart-demo/README.md
+++ b/guardrails-quickstart-demo/README.md
@@ -12,7 +12,7 @@
 This will download the model binaries to your cluster and host them in an emulated S3-bucket:
 ```bash
 oc new-project model-namespace || oc project model-namespace
-oc apply -f model_storage_container 
+oc apply -f model_storage_container.yaml
 ```
 
 This will take a minute to spin up- once `oc get pods` reports 


### PR DESCRIPTION
Add missing `.yaml`.