### PR TITLE
Missing space in yaml config was causing a failure in deployment

### DIFF
--- a/lemonade-stand-demo/guardrails/orchestrator.yaml
+++ b/lemonade-stand-demo/guardrails/orchestrator.yaml
@@ -35,7 +35,7 @@ data:
       host: "localhost"
       port: 8032
     detectors:
-      - name:built_in
+      - name: built_in
         input: true
         output: true
         detector_params:


### PR DESCRIPTION
Really simple fix, but I was stuck wondering why the pod wasn't coming online